### PR TITLE
Fix navigation bar alignment issues on Xcode 11.4

### DIFF
--- a/MusicArchive/Views/ContentContainerView.swift
+++ b/MusicArchive/Views/ContentContainerView.swift
@@ -35,7 +35,6 @@ struct ContentContainerView: View {
                 .environmentObject(AudioPlayer.shared)
                 .offset(x: 0, y: -49)
         }
-        .edgesIgnoringSafeArea(.top)
         .overlay(!self.authorizer.authorized ? AuthView().environmentObject(authorizer).background(Color(UIColor.systemBackground)) : nil)
         .navigationViewStyle(StackNavigationViewStyle())
     }


### PR DESCRIPTION
Fixes #2. Tip from this Tweet: https://twitter.com/OscarGorog/status/1242584923795423233